### PR TITLE
oneplus2: Update config_safe_media_volume_index overlay

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -188,6 +188,9 @@
     <!-- If this is true, the screen will come on when you unplug usb/power/whatever. -->
     <bool name="config_unplugTurnsOnScreen">true</bool>
 
+    <!-- reference volume index for music stream to limit headphone volume and display warning -->
+    <integer name="config_safe_media_volume_index">16</integer>
+
     <!-- Set to true to add links to Cell Broadcast app from Settings and MMS app. -->
     <bool name="config_cellBroadcastAppLinks">true</bool>
 


### PR DESCRIPTION
* Media volume steps were increased from 15 to 25,
  multiply 10 * 1,666666667 to reflect the step change

Change-Id: Id44247fb297b3fcef9e98bfb8c9ccf9b7a63dfff