### PR TITLE
oneplus2: Drop net_raw permissions from per_mgr

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -396,7 +396,7 @@ service perfd /vendor/bin/perfd
 service per_mgr /vendor/bin/pm-service
     class late_start
     user system
-    group system net_raw
+    group system
     ioprio rt 4
     writepid /dev/cpuset/system-background/tasks
 


### PR DESCRIPTION
Peripheral manager hosts a QMI service. It no longer needs net_raw
permissions but does require CAP_NET_BIND instead.

Change-Id: Ia0d6a893e1c32c1fe7225b7f59d225acfea4cc61